### PR TITLE
편집 중 상태 표시 및 자동 ping 갱신 기능 추가

### DIFF
--- a/pages/wiki/[code].tsx
+++ b/pages/wiki/[code].tsx
@@ -75,6 +75,7 @@ export default function WikiPage() {
   const isEditableUser = session?.user?.profile?.code === code;
   const [isEditing, setIsEditing] = useState(false);
 
+  // 수정 여부 판단 get
   useEffect(() => {
     const checkEditingStatus = async () => {
       try {
@@ -288,6 +289,7 @@ export default function WikiPage() {
     }
   };
 
+  // 수정 갱신
   useEffect(() => {
     const intervalId = setInterval(async () => {
       try {
@@ -303,9 +305,8 @@ export default function WikiPage() {
       } catch (err) {
         console.error(err);
       }
-    }, 270000); // 4분 30초마다 반복 (270,000ms)
+    }, 270000); // 4분 30초마다 반복
 
-    // 컴포넌트 언마운트 시 인터벌 정리
     return () => clearInterval(intervalId);
   }, [code, inputAnswer, session?.accessToken]);
 

--- a/pages/wiki/components/WikiStepDone.tsx
+++ b/pages/wiki/components/WikiStepDone.tsx
@@ -4,14 +4,19 @@ import { Viewer, ViewerButton, ViewerContainer } from '../style';
 interface Props {
   content: string;
   onStart: () => void;
+  isEditing: boolean;
 }
 
-export default function WikiStepDone({ content, onStart }: Props) {
+export default function WikiStepDone({ content, onStart, isEditing }: Props) {
   return (
     <ViewerContainer>
       <Viewer dangerouslySetInnerHTML={{ __html: content }} />
       <ViewerButton>
-        <Button onClick={onStart}>위키 참여하기</Button>
+        {isEditing ? (
+          <Button disabled>편집 중..</Button>
+        ) : (
+          <Button onClick={onStart}>위키 참여하기</Button>
+        )}
       </ViewerButton>
     </ViewerContainer>
   );


### PR DESCRIPTION
## ✨ 요약
편집 중 상태 표시 및 자동 ping 갱신 기능 추가

## 📌 주요 변경 사항
- 프로필 수정 중일 때 '편집 중' 상태를 표시하고 버튼 비활성화 처리
- 프로필 수정 중일 경우 4분 30초마다 자동으로 수정 중 상태를 갱신

## ✅ 체크리스트
- [x] 컨벤션 지켰는가
- [x] 테스트 통과했는가
- [x] 간단명료하게 작성했는가
- [x] develop로 PR 보내고 있는가

## 💬 기타 참고 사항
현재 수정 완료 상태를 서버에 보내는 API가 없어서 수정 완료 후에도 수정 시작 시간부터 5분을 기다려야 편집을 할 수 있습니다. (새로 고침 시 편집 중 상태로 변경됩니다) 수정 완료 상태에 대해 여쭤봤는데 현재로서는 프론트에서 해결할 수 없다고 답변을 받았습니다.